### PR TITLE
Feat 1.2

### DIFF
--- a/operator-config.yaml
+++ b/operator-config.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   replicas: 1
   namespace: typesense
-  image: typesense/typesense:0.24.1
+  image: typesense/typesense:0.25.0
   resources:
     requests:
       memory: 100Mi

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -46,6 +46,18 @@ spec:
         ports:
         - containerPort: 8108
           name: typesense-http
+        startupProbe:
+          httpGet:
+            path: /health
+            port: typesense-http
+          failureThreshold: 10
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: typesense-http
+          failureThreshold: 2
+          periodSeconds: 10
         # NOTE: you can increase these resources
         resources:
           requests:

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -10,6 +10,7 @@ metadata:
 spec:
   serviceName: ts
   podManagementPolicy: Parallel
+  publishNotReadyAddresses: true
   replicas: 3
   selector:
     matchLabels:
@@ -30,7 +31,7 @@ spec:
       containers:
       - name: typesense
         # NOTE : you can update to the latest release
-        image: typesense/typesense:0.24.1
+        image: typesense/typesense:0.25.0
         command:
           - "/opt/typesense-server"
           - "-d"


### PR DESCRIPTION
# Changes for version 1.2
- The `publishNotReadyAddresses=True` is set to support headless services discovery in stateful sets
- Introducing `liveness` and `startup` probes as requested #2  
- Base files updated to support latest Typesense version