### PR TITLE
Statefulset does not support publishNotReadyAddresses option

### DIFF
--- a/templates/headless-service.yaml
+++ b/templates/headless-service.yaml
@@ -5,6 +5,7 @@ metadata:
   name: ts
   namespace: typesense
 spec:
+  publishNotReadyAddresses: true
   clusterIP: None
   selector:
     app: typesense

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -10,7 +10,6 @@ metadata:
 spec:
   serviceName: ts
   podManagementPolicy: Parallel
-  publishNotReadyAddresses: true
   replicas: 3
   selector:
     matchLabels:


### PR DESCRIPTION
This option must be defined in the headless service resource

![Screenshot from 2023-11-02 12-34-18](https://github.com/sai3010/Typesense-Kubernetes-Operator/assets/112009202/57ca5763-9f09-4467-bef6-d89a07cbcc00)
