### PR TITLE
Deploy operator resources into a custom namespace

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: typesense-operator
   name: typesense-operator
-  namespace: default
+  namespace: typesense-operator
 spec:
   replicas: 1
   selector:

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -1,8 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: typesense-operator
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: "default"
+  namespace: typesense-operator
   name: typesense-operator-sa
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -34,7 +38,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: "default"
+  namespace: typesense-operator
   name: typesenseoperator-role-namespaced
 rules:
 
@@ -63,12 +67,12 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: typesense-operator-sa
-    namespace: "default"
+    namespace: typesense-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  namespace: "default"
+  namespace: typesense-operator
   name: typesenseoperator-rolebinding-namespaced
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operator-config.yaml
+++ b/operator-config.yaml
@@ -3,6 +3,7 @@ apiVersion: typesenseproject.org/v1
 kind: TypesenseOperator
 metadata:
   name: type-operator
+  namespace: typesense-operator
 spec:
   replicas: 1
   namespace: typesense


### PR DESCRIPTION
All operator resources were moved from default namespace to typesense-operator namespace.