### PR TITLE
Ssolerg/config startupprobe from operator config

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ kubectl create -f operator-config.yaml
         - `name` : Name of the storageClass that the operator should consider for volume mount.
         - `size` : Size of the volume to be allocated to each typesense replica.<br>
         **NOTE**: Supports all [k8s Storageclass](https://kubernetes.io/docs/concepts/storage/storage-classes/).
+    - `startupProbe` : Protect slow starting containers with startup probes <br>
+    Options available are `failureThreshold` and `periodSeconds` <br>
+    **NOTE**: [k8s startupProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes).
+    - `livenessProbe` :  Kubernetes provides liveness probes to detect and remedy such situations. <br>
+    Options available are `failureThreshold` and `periodSeconds`<br>
+    **NOTE**: [k8s livenessProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-http-request).
 - Supported configurations under `config`
     - `password` : Typesense authentication is done using a password. defaults to `297beb01dd21c`
     ## Deploying the configuration

--- a/deployment_utils.py
+++ b/deployment_utils.py
@@ -29,6 +29,18 @@ def validate_spec(op_spec: dict) -> dict:
             return_data['storageClassName'] = spec['storageClass']['name']
             return_data['storage'] = spec['storageClass']['size']
 
+        if spec.get('startupProbe'):
+            if not spec['startupProbe'].get('failureThreshold') or not spec['startupProbe'].get('periodSeconds'):
+                raise Exception('Missing startupProbe properties. Required: failureThreshold, periodSeconds')            
+            return_data['startupProbe_failureThreshold'] = spec['startupProbe']['failureThreshold']
+            return_data['startupProbe_periodSeconds'] = spec['startupProbe']['periodSeconds']
+
+        if spec.get('livenessProbe'):
+            if not spec['livenessProbe'].get('failureThreshold') or not spec['livenessProbe'].get('periodSeconds'):
+                raise Exception('Missing livenessProbe properties. Required: failureThreshold, periodSeconds')            
+            return_data['livenessProbe_failureThreshold'] = spec['livenessProbe']['failureThreshold']
+            return_data['livenessProbe_periodSeconds'] = spec['livenessProbe']['periodSeconds']
+
     if config:
         return_data['password'] = config.get('password','297beb01dd21c')
     return return_data
@@ -110,6 +122,15 @@ def deploy_typesense_statefulset(apps_obj: object,spec: dict,update=False) -> No
             configuration['spec']['template']['spec']['containers'][0]['command'][4] = spec['password']
         if spec.get('replicas'):
             configuration['spec']['replicas'] = spec['replicas']
+
+        if spec.get('startupProbe_failureThreshold') and spec.get('startupProbe_periodSeconds'):            
+            configuration['spec']['template']['spec']['containers'][0]['startupProbe']['failureThreshold'] = spec['startupProbe_failureThreshold']
+            configuration['spec']['template']['spec']['containers'][0]['startupProbe']['periodSeconds'] = spec['startupProbe_periodSeconds']
+
+        if spec.get('livenessProbe_failureThreshold') and spec.get('livenessProbe_periodSeconds'):            
+            configuration['spec']['template']['spec']['containers'][0]['livenessProbe']['failureThreshold'] = spec['livenessProbe_failureThreshold']
+            configuration['spec']['template']['spec']['containers'][0]['livenessProbe']['periodSeconds'] = spec['livenessProbe_periodSeconds']
+        
         if update:
             configuration["spec"]["template"]["metadata"]["annotations"] = {
             "kubectl.kubernetes.io/restartedAt": datetime.datetime.utcnow().isoformat()

--- a/operator-config.yaml
+++ b/operator-config.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   replicas: 1
   namespace: typesense
-  image: typesense/typesense:0.25.0
+  image: typesense/typesense:0.25.2
   resources:
     requests:
       memory: 100Mi
@@ -19,5 +19,11 @@ spec:
   # storageClass:
   #   name: standard
   #   size: "100Mi"
+  # startupProbe:
+  #  failureThreshold: 10
+  #  periodSeconds: 10
+  # livenessProbe:    
+  #  failureThreshold: 2
+  #  periodSeconds: 10
 config:
   password: "123456789"

--- a/templates/headless-service.yaml
+++ b/templates/headless-service.yaml
@@ -5,6 +5,7 @@ metadata:
   name: ts
   namespace: typesense
 spec:
+  publishNotReadyAddresses: true
   clusterIP: None
   selector:
     app: typesense

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -10,7 +10,6 @@ metadata:
 spec:
   serviceName: ts
   podManagementPolicy: Parallel
-  publishNotReadyAddresses: true
   replicas: 3
   selector:
     matchLabels:

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -30,7 +30,7 @@ spec:
       containers:
       - name: typesense
         # NOTE : you can update to the latest release
-        image: typesense/typesense:0.25.0
+        image: typesense/typesense:0.25.2
         command:
           - "/opt/typesense-server"
           - "-d"


### PR DESCRIPTION

1. From this [issue](https://github.com/typesense/typesense/issues/1590). Updating the default values of the startupProbe and livenessProbe is enabled from the operator configuration file.
2. Using typesense 0.25.2 as default version.
