### PR TITLE
Fix: Operator unable to identify the secrets

### DIFF
--- a/deployment_utils.py
+++ b/deployment_utils.py
@@ -9,6 +9,7 @@ def validate_spec(op_spec: dict, k8s_core_v1=None, action=None) -> dict:
     '''
     spec = op_spec['new'].get('spec',None)
     config = op_spec['new'].get('config',None)
+    operator_namespace = op_spec.get('operator_namespace')
     return_data = {}
     if spec:
         if spec.get('resources'):
@@ -47,13 +48,12 @@ def validate_spec(op_spec: dict, k8s_core_v1=None, action=None) -> dict:
                not constraints.get('whenUnsatisfiable') or not constraints.get('labelSelector'):
                     raise Exception('Missing topologySpreadConstraints properties. Required: maxSkew, topologyKey, whenUnsatisfiable, labelSelector')
             return_data['topologySpreadConstraints'] = spec['topologySpreadConstraints']
-    
     if config and action!='delete':
         '''
         Get APIKEY from secret
         '''
         secret_name = config.get('secret','typesense-apikey')
-        secret = k8s_core_v1.read_namespaced_secret(name=secret_name,namespace=return_data['namespace'])
+        secret = k8s_core_v1.read_namespaced_secret(name=secret_name,namespace=operator_namespace)
         secret_data = secret.data
         if not secret_data:
             raise Exception("Secret for APIKey not found")

--- a/handler.py
+++ b/handler.py
@@ -22,6 +22,8 @@ def create_fn(body, **kwargs):
         config.load_kube_config()
     k8s_apps_v1 = client.AppsV1Api()
     k8s_core_v1 = client.CoreV1Api()
+    operator_namespace = body.get('metadata', {}).get('namespace', 'default')
+    kwargs['operator_namespace'] = operator_namespace
     spec = validate_spec(kwargs, k8s_core_v1)
     create_modify_namespace(k8s_core_v1,namespace=spec['namespace'])
     deploy_configmap(k8s_core_v1,replicas=spec['replicas'],namespace=spec['namespace'])

--- a/operator-config.yaml
+++ b/operator-config.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   replicas: 1
   namespace: typesense
-  image: typesense/typesense:27.1
+  image: typesense/typesense:28.0
   env:
   - name: APIKEY
     valueFrom:
@@ -18,7 +18,7 @@ spec:
       memory: 100Mi
       cpu: "100m"
     limits:
-      memory: 200Mi
+      memory: 300Mi
       cpu: "100m"
   nodeSelector:
     kubernetes.io/os: linux


### PR DESCRIPTION
## Problem
- Even after creating the secret1 `kubectl create secret generic -n <namespace> typesense-apikey` in the same namespace as that of the operator, the operator was unable to recognize it due to a bug.
- This has now been fixed here.